### PR TITLE
Updates in ConnectionPool in order to use React\Async\await function

### DIFF
--- a/src/ConnectionPool.php
+++ b/src/ConnectionPool.php
@@ -55,7 +55,7 @@ class ConnectionPool implements ConnectionPoolInterface
                 $this->connections->attach($this->makeNewConnection());
                 return $this->get();
             }
-            return $this->retryWithDelay();
+            return await($this->retryWithDelay());
         }
 
         return $connection;
@@ -76,7 +76,7 @@ class ConnectionPool implements ConnectionPoolInterface
         return ($this->connectionFactory)();
     }
 
-    protected function retryWithDelay(Deferred $deferred = null): ConnectionAdapterInterface
+    protected function retryWithDelay(Deferred $deferred = null): \React\Promise\Promise
     {
         if ($this->retryLimit !== null && $this->retryLimit < 1) {
             throw new ConnectionPoolException('No available connection to use');
@@ -106,6 +106,6 @@ class ConnectionPool implements ConnectionPoolInterface
             $this->retryWithDelay($deferred);
         });
 
-        return await($deferred->promise());
+        return $deferred->promise();
     }
 }


### PR DESCRIPTION
According to [some issues](https://github.com/reactphp/async/issues/16) when `ConnectionState` enum (of $connectionFactory Closure/Class, which creates connection adapter) isn't `Ready` and `retryWithDelay()` function is called repeatedly.

I used to debug calls that used in your [test.php](https://github.com/szado/reactphp-connection-pool/blob/master/test.php) file.

If you want better code readability you can use this variation of `retryWithDelay()` function (notice additional $selectConnectionDeferred):
```
protected function retryWithDelay(Deferred $deferred = null): \React\Promise\Promise
{
      if ($this->retryLimit !== null && $this->retryLimit < 1) {
          throw new ConnectionPoolException('No available connection to use');
      }

      $deferred ??= new Deferred();

      if (!$this->awaiting->contains($deferred)) {
          $this->awaiting->attach($deferred, 0);
      }

      if ($this->awaiting[$deferred] === $this->retryLimit) {
          $this->awaiting->detach($deferred);
          throw new ConnectionPoolException("No available connection to use; $this->retryLimit attempts were made");
      }

      $selectConnectionDeferred = new Deferred();

      $this->loop->addTimer($this->retryEverySec, function () use ($deferred, $selectConnectionDeferred) {
          $connectionAdapter = $this->selectConnection();

          if ($connectionAdapter) {
              $this->awaiting->detach($deferred);
              $selectConnectionDeferred->resolve(true);
              $deferred->resolve($connectionAdapter);
              return;
          }

          $this->awaiting[$deferred] = $this->awaiting[$deferred] + 1;
          $selectConnectionDeferred->resolve(false);
      });

      return $selectConnectionDeferred->promise()->then(function($connectionSelected) use ($deferred) {
          return $connectionSelected ? $deferred->promise() : $this->retryWithDelay($deferred);
      });
}
```